### PR TITLE
Implement piece movement rules and add tests

### DIFF
--- a/movement_tests.cpp
+++ b/movement_tests.cpp
@@ -1,0 +1,107 @@
+#define UNIT_TEST
+#include "main.cpp"
+#include <cassert>
+#include <iostream>
+
+void resetBoardState() {
+    for (int r = 0; r < 8; ++r) {
+        for (int c = 0; c < 8; ++c) {
+            if (board[r][c]) {
+                delete board[r][c];
+                board[r][c] = nullptr;
+            }
+        }
+    }
+    selectedPiece = nullptr;
+    selectedPos = sf::Vector2i(-1, -1);
+}
+
+Piece* makePiece(const std::string& type, bool white) {
+    Piece* p = new Piece;
+    p->type = type;
+    p->isWhite = white;
+    return p;
+}
+
+void testWhitePawn() {
+    resetBoardState();
+    Piece* p = makePiece("white-pawn", true);
+    board[6][4] = p;
+    selectedPiece = p;
+    selectedPos = {6,4};
+    moveWhitePawn(5,4);
+    assert(board[5][4] == p && board[6][4] == nullptr);
+}
+
+void testBlackPawn() {
+    resetBoardState();
+    Piece* p = makePiece("black-pawn", false);
+    board[1][3] = p;
+    selectedPiece = p;
+    selectedPos = {1,3};
+    moveBlackPawn(2,3);
+    assert(board[2][3] == p && board[1][3] == nullptr);
+}
+
+void testRook() {
+    resetBoardState();
+    Piece* p = makePiece("white-rook", true);
+    board[4][4] = p;
+    selectedPiece = p;
+    selectedPos = {4,4};
+    moveRook(4,7);
+    assert(board[4][7] == p && board[4][4] == nullptr);
+}
+
+void testKnight() {
+    resetBoardState();
+    Piece* p = makePiece("white-knight", true);
+    board[4][4] = p;
+    selectedPiece = p;
+    selectedPos = {4,4};
+    moveKnight(5,6);
+    assert(board[5][6] == p && board[4][4] == nullptr);
+}
+
+void testBishop() {
+    resetBoardState();
+    Piece* p = makePiece("white-bishop", true);
+    board[4][4] = p;
+    selectedPiece = p;
+    selectedPos = {4,4};
+    moveBishop(6,6);
+    assert(board[6][6] == p && board[4][4] == nullptr);
+}
+
+void testQueen() {
+    resetBoardState();
+    Piece* p = makePiece("white-queen", true);
+    board[4][4] = p;
+    selectedPiece = p;
+    selectedPos = {4,4};
+    moveQueen(4,6);
+    assert(board[4][6] == p && board[4][4] == nullptr);
+}
+
+void testKing() {
+    resetBoardState();
+    Piece* p = makePiece("white-king", true);
+    board[4][4] = p;
+    selectedPiece = p;
+    selectedPos = {4,4};
+    moveKing(5,5);
+    assert(board[5][5] == p && board[4][4] == nullptr);
+}
+
+int main() {
+    testWhitePawn();
+    testBlackPawn();
+    testRook();
+    testKnight();
+    testBishop();
+    testQueen();
+    testKing();
+    std::cout << "All movement tests passed\n";
+    resetBoardState();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add helper functions and full movement rules for pawns, rooks, bishops, knights, queens, and kings
- dispatch `movePiece` to route each piece type to its movement logic
- introduce simple movement tests validating each piece's behaviour

## Testing
- `g++ movement_tests.cpp -lsfml-graphics -lsfml-window -lsfml-system -std=c++17 -o movement_tests && ./movement_tests` *(fails: SFML/Graphics.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689f5093f2a8832c8bfc4f8b3b85aa9b