### PR TITLE
Implement turn-based play

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,7 @@ struct Piece {
 Piece* selectedPiece = nullptr;
 sf::Vector2i selectedPos;
 Piece* board[8][8] = {nullptr};
+bool isWhiteTurn = true;
 
 bool isInsideBoard(int row, int col) {
     return row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE;
@@ -40,6 +41,7 @@ void finalizeMove(int startRow, int startCol, int row, int col) {
     std::cout << "Moved piece: " << selectedPiece->type << " to (" << col << ", " << row << ")\n";
     selectedPiece = nullptr;
     selectedPos = sf::Vector2i(-1, -1);
+    isWhiteTurn = !isWhiteTurn;
 }
 
 void drawBoard(sf::RenderWindow& window) {
@@ -136,20 +138,16 @@ void moveWhitePawn(int row, int col) {
     }
     // Capture move
     else if (abs(dx) == 1 && dy == -1 && board[row][col] != nullptr && !board[row][col]->isWhite) {
-        delete board[row][col]; // capture
         moved = true;
     }
 
     if (moved) {
-        board[row][col] = selectedPiece;
-        board[startRow][startCol] = nullptr;
-        std::cout << "Moved piece: " << selectedPiece->type << " to (" << col << ", " << row << ")\n";
+        finalizeMove(startRow, startCol, row, col);
     } else {
         std::cout << "Invalid move for piece: " << selectedPiece->type << "\n";
+        selectedPiece = nullptr;
+        selectedPos = sf::Vector2i(-1, -1);
     }
-
-    selectedPiece = nullptr;
-    selectedPos = sf::Vector2i(-1, -1);
 }
 
 void moveBlackPawn(int row, int col) {
@@ -176,7 +174,6 @@ void moveBlackPawn(int row, int col) {
     }
     // Capture move
     else if (abs(dx) == 1 && dy == 1 && board[row][col] != nullptr && board[row][col]->isWhite) {
-        delete board[row][col];
         moved = true;
     }
 
@@ -306,7 +303,7 @@ void movePiece(int row, int col, sf::RenderWindow& window) {
     if (!isInsideBoard(row, col)) return;
 
     if (!selectedPiece) {
-        if (board[row][col] != nullptr) {
+        if (board[row][col] != nullptr && board[row][col]->isWhite == isWhiteTurn) {
             selectedPiece = board[row][col];
             selectedPos = sf::Vector2i(row, col);
         }

--- a/movement_tests.cpp
+++ b/movement_tests.cpp
@@ -14,6 +14,7 @@ void resetBoardState() {
     }
     selectedPiece = nullptr;
     selectedPos = sf::Vector2i(-1, -1);
+    isWhiteTurn = true;
 }
 
 Piece* makePiece(const std::string& type, bool white) {
@@ -93,6 +94,23 @@ void testKing() {
     assert(board[5][5] == p && board[4][4] == nullptr);
 }
 
+void testTurnSwitch() {
+    resetBoardState();
+    Piece* wp = makePiece("white-pawn", true);
+    board[6][0] = wp;
+    selectedPiece = wp;
+    selectedPos = {6,0};
+    moveWhitePawn(5,0);
+    assert(!isWhiteTurn);
+
+    Piece* bp = makePiece("black-pawn", false);
+    board[1][0] = bp;
+    selectedPiece = bp;
+    selectedPos = {1,0};
+    moveBlackPawn(2,0);
+    assert(isWhiteTurn);
+}
+
 int main() {
     testWhitePawn();
     testBlackPawn();
@@ -101,6 +119,7 @@ int main() {
     testBishop();
     testQueen();
     testKing();
+    testTurnSwitch();
     std::cout << "All movement tests passed\n";
     resetBoardState();
     return 0;


### PR DESCRIPTION
## Summary
- Track whose turn it is with `isWhiteTurn` and switch turns after each valid move
- Allow selecting only pieces of the current player
- Add unit test ensuring turns alternate and reset state properly

## Testing
- `g++ -std=c++17 movement_tests.cpp -lsfml-graphics -lsfml-window -lsfml-system -o movement_tests` *(fails: SFML/Graphics.hpp: No such file or directory)*
- `apt-get update` *(fails: repository not signed/403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f55fd0504832ca5d3172bf0cf9de7