### PR TITLE
Add pawn promotion selection

### DIFF
--- a/movement_tests.cpp
+++ b/movement_tests.cpp
@@ -150,6 +150,17 @@ void testNoLeavingKingInCheck() {
     assert(board[4][0] == wRook && board[4][1] == nullptr);
 }
 
+void testPawnPromotion() {
+    resetBoardState();
+    Piece* p = makePiece("white-pawn", true);
+    board[1][0] = p;
+    selectedPiece = p;
+    selectedPos = {1,0};
+    moveWhitePawn(0,0);
+    assert(board[0][0] == p);
+    assert(board[0][0]->type == "white-queen");
+}
+
 int main() {
     testWhitePawn();
     testBlackPawn();
@@ -162,6 +173,7 @@ int main() {
     testCannotCaptureKing();
     testDetectCheck();
     testNoLeavingKingInCheck();
+    testPawnPromotion();
     std::cout << "All movement tests passed\n";
     resetBoardState();
     return 0;


### PR DESCRIPTION
## Summary
- Allow players to promote pawns to their choice of rook, bishop, knight or queen
- Manage textures globally for easier piece creation
- Add unit test for pawn promotion

## Testing
- `g++ -std=c++17 movement_tests.cpp -lsfml-graphics -lsfml-window -lsfml-system && ./a.out` *(fails: SFML/Graphics.hpp: No such file or directory)*
- `apt-get update` *(fails: repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f59fcb470832c926c2d035398c7f5