### PR TITLE
Integrate ChatGPT-based AI move suggestion

### DIFF
--- a/chatgpt_move.py
+++ b/chatgpt_move.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""
+Query OpenAI's ChatGPT for a chess move.
+
+The script reads a simple board description as its first argument and expects
+an API key in the OPENAI_API_KEY environment variable. It prints a move in the
+format "sr sc er ec" to stdout. If anything goes wrong, a fallback move of
+"0 0 0 0" is returned.
+"""
+import os
+import sys
+
+
+def main() -> None:
+    board = sys.argv[1] if len(sys.argv) > 1 else ""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        print("0 0 0 0")
+        return
+    try:
+        import openai  # type: ignore
+    except Exception:
+        print("0 0 0 0")
+        return
+    openai.api_key = api_key
+    prompt = (
+        "You are a chess engine playing black. Given the board state: "
+        + board
+        + "\nReturn four integers 'sr sc er ec' for your move."
+    )
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": "You suggest legal chess moves for black and respond with four integers."},
+                {"role": "user", "content": prompt},
+            ],
+            max_tokens=10,
+            temperature=0,
+        )
+        move = response["choices"][0]["message"]["content"].strip()
+        print(move)
+    except Exception:
+        print("0 0 0 0")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add helper to serialize the board and request AI moves from ChatGPT
- Extend `aiMove` to consult ChatGPT before using random moves
- Provide Python script that queries OpenAI for a move

## Testing
- `g++ -std=c++17 movement_tests.cpp -lsfml-graphics -lsfml-window -lsfml-system -o movement_tests` (fails: SFML/Graphics.hpp: No such file or directory)
- `apt-get update` (fails: 403 Forbidden)
- `apt-get install -y libsfml-dev` (fails: Unable to locate package libsfml-dev)


------
https://chatgpt.com/codex/tasks/task_e_68a4c0bd73c4832c9743276c6c4e7d93